### PR TITLE
Update version of ubuntu and bind9

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
-FROM ubuntu:bionic-20200403
+FROM ubuntu:focal-20220113
 
 ENV BIND_USER=bind \
-    BIND_VERSION=9.11.3 \
+    BIND_VERSION=9.16.1-0ubuntu2 \
     DATA_DIR=/data
 
 RUN apt-get update \


### PR DESCRIPTION
Updated version of Ubuntu and BIND by a vulnerability detected in the BIND version 9.11.3 